### PR TITLE
Fix editor not ready

### DIFF
--- a/src/JsonEditorWidget.php
+++ b/src/JsonEditorWidget.php
@@ -132,9 +132,9 @@ var {$widgetId} = new JSONEditor(document.getElementById('{$containerId}'), {$cl
     } catch (e) {
         console.warn('Could not parse initial value for {$widgetId}, error: '+e);
     }
-});
-{$widgetId}.on('change', function() {
-    document.getElementById('{$inputId}').value = JSON.stringify({$widgetId}.getValue());
+    {$widgetId}.on('change', function() {
+        document.getElementById('{$inputId}').value = JSON.stringify({$widgetId}.getValue());
+    });
 });
 JS
 , $view::POS_READY);

--- a/src/JsonEditorWidget.php
+++ b/src/JsonEditorWidget.php
@@ -124,12 +124,15 @@ class JsonEditorWidget extends BaseWidget{
         $view->registerJs(
 <<<JS
 var {$widgetId} = new JSONEditor(document.getElementById('{$containerId}'), {$clientOptions});
-try {
-    var initialValue = JSON.parse(document.getElementById('{$inputId}').value);
-    {$widgetId}.setValue(initialValue);
-} catch (e) {
-    console.log('Could not parse initial value for {$widgetId}');
-}
+{$widgetId}.on('ready', function() {
+    try {
+        var initialValue = JSON.parse(document.getElementById('{$inputId}').value);
+        // Set the value
+        {$widgetId}.setValue(initialValue);;
+    } catch (e) {
+        console.warn('Could not parse initial value for {$widgetId}, error: '+e);
+    }
+});
 {$widgetId}.on('change', function() {
     document.getElementById('{$inputId}').value = JSON.stringify({$widgetId}.getValue());
 });


### PR DESCRIPTION
Use ready state to set the initial value. This prevents error "JSON Editor not ready yet.  Listen for 'ready' event before setting the value" which can be caused when using ajax $ref in the schema.
